### PR TITLE
hide links, handle message edits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Injector, settings } from "replugged";
 import { OutgoingMessage } from "replugged/dist/renderer/modules/webpack/common/messages";
 import { Config, Emoji } from "./types";
-import { CloudUploader, EmojiInfo, MessageParser, SelectedGuildStore } from "./webpack";
+import { EmojiInfo, MessageParser, SelectedGuildStore } from "./webpack";
 
 const injector = new Injector();
 const config = await settings.init<Config>("com.cafeed28.NitroSpoof");
@@ -41,26 +41,18 @@ function replaceEmojis(message: OutgoingMessage): void {
     const extension = emoji.animated ? "gif" : "webp";
     const replaceUrl = `https://cdn.discordapp.com/emojis/${emoji.id}.${extension}?size=${size}`; // TODO: ui for this (when replugged settings ui is done)
 
-    const hideLinks = config.get("hideLinks", true);
-
-    // Move emoji to the end and hide its link
     if (hideLinks && message.content.length > searchString.length) {
+      // Move emoji to the end and hide its link
       message.content = message.content.replace(searchString, "");
       if (!message.content.includes(HIDE_TEXT_SPOILERS)) message.content += HIDE_TEXT_SPOILERS;
-      message.content += " " + searchString;
+      message.content += " " + replaceUrl + " ";
+    } else {
+      message.content = message.content.replace(searchString, replaceUrl);
     }
-
-    message.content = message.content.replace(searchString, replaceUrl);
   }
 }
 
 export function start(): void {
-  injector.before(CloudUploader, "uploadFiles", (args) => {
-    const message = args[0].parsedMessage;
-    replaceEmojis(message);
-    return args;
-  });
-
   injector.after(MessageParser, "parse", (args, message) => {
     replaceEmojis(message);
     return message;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
-import { Injector, common, settings } from "replugged";
-import { CloudUploader, EmojiInfo, SelectedGuildStore } from "./webpack";
-import { Config, Emoji } from "./types";
+import { Injector, settings } from "replugged";
 import { OutgoingMessage } from "replugged/dist/renderer/modules/webpack/common/messages";
+import { Config, Emoji } from "./types";
+import { CloudUploader, EmojiInfo, MessageParser, SelectedGuildStore } from "./webpack";
 
 const injector = new Injector();
 const config = await settings.init<Config>("com.cafeed28.NitroSpoof");
+
+const HIDE_TEXT_SPOILERS = "||\u200b||".repeat(199);
 
 // TODO: test with nitro
 function isEmojiAvailable(emoji: Emoji): boolean {
@@ -39,6 +41,15 @@ function replaceEmojis(message: OutgoingMessage): void {
     const extension = emoji.animated ? "gif" : "webp";
     const replaceUrl = `https://cdn.discordapp.com/emojis/${emoji.id}.${extension}?size=${size}`; // TODO: ui for this (when replugged settings ui is done)
 
+    const hideLinks = config.get("hideLinks", true);
+
+    // Move emoji to the end and hide its link
+    if (hideLinks && message.content.length > searchString.length) {
+      message.content = message.content.replace(searchString, "");
+      if (!message.content.includes(HIDE_TEXT_SPOILERS)) message.content += HIDE_TEXT_SPOILERS;
+      message.content += " " + searchString;
+    }
+
     message.content = message.content.replace(searchString, replaceUrl);
   }
 }
@@ -50,10 +61,9 @@ export function start(): void {
     return args;
   });
 
-  injector.before(common.messages, "sendMessage", (args) => {
-    const [, message] = args;
+  injector.after(MessageParser, "parse", (args, message) => {
     replaceEmojis(message);
-    return args;
+    return message;
   });
 
   injector.instead(EmojiInfo, "isEmojiDisabled", () => false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ function replaceEmojis(message: OutgoingMessage): void {
     const size = config.get("emojiSize", 48);
     const extension = emoji.animated ? "gif" : "webp";
     const replaceUrl = `https://cdn.discordapp.com/emojis/${emoji.id}.${extension}?size=${size}`; // TODO: ui for this (when replugged settings ui is done)
+    const hideLinks = config.get("hideLinks", false);
 
     if (hideLinks && message.content.length > searchString.length) {
       // Move emoji to the end and hide its link

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { ModuleExports } from "replugged/dist/types";
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type Config = {
   emojiSize: number;
+  hideLinks: boolean;
 };
 
 export interface Emoji {
@@ -29,4 +30,8 @@ export type EmojiInfoType = ModuleExports & {
 
 export type CloudUploaderType = ModuleExports & {
   uploadFiles: (args: { parsedMessage: OutgoingMessage }) => void;
+};
+
+export type MessageParserType = {
+  parse: (message: unknown, content: string) => OutgoingMessage;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,10 +28,6 @@ export type EmojiInfoType = ModuleExports & {
   isEmojiDisabled: (...args: unknown[]) => boolean;
 };
 
-export type CloudUploaderType = ModuleExports & {
-  uploadFiles: (args: { parsedMessage: OutgoingMessage }) => void;
-};
-
 export type MessageParserType = {
   parse: (message: unknown, content: string) => OutgoingMessage;
 };

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -1,6 +1,11 @@
 import { webpack } from "replugged";
 
-import { CloudUploaderType, EmojiInfoType, SelectedGuildStoreType } from "./types";
+import {
+  CloudUploaderType,
+  EmojiInfoType,
+  MessageParserType,
+  SelectedGuildStoreType,
+} from "./types";
 
 export const SelectedGuildStore: SelectedGuildStoreType = webpack.getExportsForProps(
   webpack.getByProps("getLastSelectedGuildId")!,
@@ -11,6 +16,8 @@ export const EmojiInfo: EmojiInfoType = webpack.getExportsForProps(
   webpack.getByProps("getEmojiUnavailableReason")!,
   ["getEmojiUnavailableReason"],
 ) as unknown as EmojiInfoType;
+
+export const MessageParser = webpack.getByProps("parse", "parsePreprocessor") as MessageParserType;
 
 export const CloudUploader = await webpack.waitForModule<CloudUploaderType>(
   webpack.filters.byProps("uploadFiles"),

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -18,7 +18,3 @@ export const EmojiInfo: EmojiInfoType = webpack.getExportsForProps(
 ) as unknown as EmojiInfoType;
 
 export const MessageParser = webpack.getByProps("parse", "parsePreprocessor") as MessageParserType;
-
-export const CloudUploader = await webpack.waitForModule<CloudUploaderType>(
-  webpack.filters.byProps("uploadFiles"),
-);


### PR DESCRIPTION
uses spoiler + zero width space magic to hide the link:

before:
![image](https://user-images.githubusercontent.com/55899582/210017034-de7a236e-0309-4fc6-a526-0a11219b46ee.png)
after:
![image](https://user-images.githubusercontent.com/55899582/210016934-5e4a6f0a-2820-4fe6-9d57-d04f9abd7db7.png)

and it injects into the parser module to also replace emojis when editing a message