### PR TITLE
fix: premium stream quality and disabled sticker spoof

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,12 +65,12 @@ export function start(): void {
 
   // Stickers
   injector.instead(stickerInfo, shouldAttachSticker, (args, orig) => {
-    if (!config.get("stickerSpoof")) return orig(args);
+    if (!config.get("stickerSpoof")) return orig(...args);
     return true;
   });
 
   injector.instead(stickerSendability, isSendableSticker, (args, orig) => {
-    if (!config.get("stickerSpoof")) return orig(args);
+    if (!config.get("stickerSpoof")) return orig(...args);
     const sticker = args[0] as Sticker;
 
     if (sticker.type == StickerType.STANDARD) return true;
@@ -79,7 +79,7 @@ export function start(): void {
   });
 
   injector.instead(stickerPreview, addStickerPreview, async (args, orig) => {
-    if (!config.get("stickerSpoof")) return orig(args);
+    if (!config.get("stickerSpoof")) return orig(...args);
 
     const [channelId, sticker, d] = args;
 
@@ -97,7 +97,7 @@ export function start(): void {
 
   // Stream quality
   injector.instead(premiumInfo, "canStreamQuality", (args, orig) => {
-    if (!config.get("streamQualityEnable")) return orig(args);
+    if (!config.get("streamQualityEnable")) return orig(...args);
     return true;
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,12 +96,7 @@ export function start(): void {
   });
 
   // Stream quality
-  injector.instead(premiumInfo, "canStreamHighQuality", (args, orig) => {
-    if (!config.get("streamQualityEnable")) return orig(args);
-    return true;
-  });
-
-  injector.instead(premiumInfo, "canStreamMidQuality", (args, orig) => {
+  injector.instead(premiumInfo, "canStreamQuality", (args, orig) => {
     if (!config.get("streamQualityEnable")) return orig(args);
     return true;
   });

--- a/src/plaintextPatches.ts
+++ b/src/plaintextPatches.ts
@@ -2,8 +2,8 @@ import { PlaintextPatch } from "replugged/dist/types";
 
 export default [
   {
-    // based on Canary df4e5b4
-    find: "canStreamHighQuality:function",
+    // based on Canary 7e44454
+    find: "canStreamQuality:function",
     replacements: [
       {
         // Removes all Object.freeze to allow PremiumInfo patching.

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -14,10 +14,9 @@ type EmojiInfo = {
 export const emojiInfo = await waitForProps<EmojiInfo>("getEmojiUnavailableReason");
 
 type PremiumInfo = {
-  canStreamHighQuality: (...args: unknown[]) => boolean;
-  canStreamMidQuality: (...args: unknown[]) => boolean;
+  canStreamQuality: (...args: unknown[]) => boolean;
 };
-export const premiumInfo = await waitForProps<PremiumInfo>("canStreamHighQuality");
+export const premiumInfo = await waitForProps<PremiumInfo>("canStreamQuality");
 
 type MessageParser = {
   parse: (message: unknown, content: string) => OutgoingMessage;


### PR DESCRIPTION
Do not merge until changes are in stable (regarding the changed function for streaming quality).
Fixes another issue while sticker spoofer was disabled. It didn't send all the arguments needed for the original function, making it impossible to send stickers for those who disabled the spoofer.